### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MMFlowView
-[![Build Status](https://travis-ci.org/mmllr/MMFlowView.png?branch=master)](https://travis-ci.org/mmllr/MMFlowView) [![Coverage Status](https://coveralls.io/repos/mmllr/MMFlowView/badge.png)](https://coveralls.io/r/mmllr/MMFlowView) [![Cocoapods Version](https://cocoapod-badges.herokuapp.com/v/MMFlowView/badge.png)](https://cocoapod-badges.herokuapp.com/v/MMFlowView/badge.png)  
+[![Build Status](https://travis-ci.org/mmllr/MMFlowView.png?branch=master)](https://travis-ci.org/mmllr/MMFlowView) [![Coverage Status](https://coveralls.io/repos/mmllr/MMFlowView/badge.png)](https://coveralls.io/r/mmllr/MMFlowView) [![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/MMFlowView/badge.png)](https://cocoapod-badges.herokuapp.com/v/MMFlowView/badge.png)  
 A full featured cover flow control for Mac OS X.
 ![Screenshot](https://raw.github.com/mmllr/MMFlowView/master/Resources/FlowView.png)
 ## Description


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
